### PR TITLE
ManuScrape v1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@
 ManuScrape is a solution for managing large amounts of observations (images mapped to custom defined parameters), including tools to collect, edit, enrich and export.
 <br />
 <br />
-There are two main actors: the project manager, and the collaborator (can only submit observations).
+There are two main actors: the *project manager* and the *collaborator* (can only submit observations).
 <br />
 <br />
 
 ## Basic feature overview:
 
-Project managers can setup projects using the web app:
+*Project managers* can setup projects using the web app:
   1. Enter project name
   2. Define observation parameters
   3. Invite collaborators by email
 
-Collaborators can then submit observations (using native app):
+*Collaborators* can submit observations using the native app:
   1. Capture image (using smart tools or file upload)
   2. Edit image
   3. Enter observation parameter values
@@ -23,35 +23,35 @@ Collaborators can then submit observations (using native app):
 
 Whether you're a collaborator or project owner isn't bound to your ManuScrape user, but to your permission role in the specific project.
 
-The project manager can at any time export the entire project into to different formats, including spreadsheets and zip files. Right now the export features are optimized to deliver formats that are easy to import into [NVivo 14](https://lumivero.com/products/nvivo/).
+The *project manager* can export the entire project into to different formats, including spreadsheets and zip files. Right now the export features are optimized to deliver formats, that are easy to import into [NVivo 14](https://lumivero.com/products/nvivo/).
 <br />
 <br />
 
 ## Installation on Windows
-Before you start installing, you need to decide where you want to put your data. As of now you can temporarily use [manuscrape.org](https://manuscrape.org) for free, and it is also the default in the signup flow.
+Before you start installing, you need to decide where you want to put your data. As of now, you can temporarily use [manuscrape.org](https://manuscrape.org) for free, which is also the default option in the signup flow.
 
 You can download a compiled windows installer, that will either install or update ManuScrape to the desired version. The latest .exe installer can be found [here](https://github.com/nikobojs/manuscrape_electron/releases).
 <br />
 <br />
 
-## Bug reports / feature requests
-After the launch of v1.0.0, we intend to use GitHub Issues for all development tasks. If you experience bugs or need features added or refactored, please [submit an issue](https://github.com/nikobojs/manuscrape_electron/issues), preferably in english.
+## Bug reports / Feature requests
+After the launch of v1.0.0, we intend to use GitHub Issues for all development tasks. If you experience bugs, or need features added or refactored, please [submit an issue](https://github.com/nikobojs/manuscrape_electron/issues), preferably in english.
 <br />
 <br />
 
 ## Contribute to the code
-You are most welcome to contribute to the project in any way. Except donations. For now.
+You are more than welcome to contribute to the project in any way. Except donations. For now.
 
 #### TL;DR:
 Clone repositories, look for TODO-comments, make improvement, create feature branch (naming doesn't matter), commit, create PR, and done! The PR will be reviewed by the project maintainers.
 <br />
 
 #### Repository overview:
-This repo is an Electron app tested continuously on Windows 11 and a couple Linux distributions. The app provides some client-side native tools that talks with the api of the online backend app. [Here is the backend repo](https://github.com/nikobojs/manuscrape_nuxt). These to repositories follows compatability with git tags (eg. `v0.9.2` client works with `v0.9.2` api).
+This repo is an Electron app tested on Windows 11 and a couple Linux distributions. The app provides some client-side native tools, that talks with the api of the online backend app. [Here is the backend repo](https://github.com/nikobojs/manuscrape_nuxt). These two repositories follows compatability with git tags (eg. `v0.9.2` client works with `v0.9.2` api).
 <br />
 
 #### Git conventions:
-Not strict in any way. We'll always figure it out so do your stuff the way you think works best. Pull requests (into "unstable" branch) on feature branches will be reviewed and merged by the current admins of the project.
+Not strict in any way. Make your contributions the way you think works best. Pull requests (into "unstable" branch) on feature branches will be reviewed and merged by the current admins of the project.
 <br />
 
 #### Setup on Linux or Mac:
@@ -69,10 +69,10 @@ Not strict in any way. We'll always figure it out so do your stuff the way you t
 _NOTE: Development ennvironment for windows is not actively maintained or tested_
 <br />
 <br />
-It is possible to setup on windows, as the app compiles on windows. However, sometimes the npm scripts does not work on windows.
+It's possible to set up a development environment on windows. However, the solution is not actively tested on windows, and there is a known issue with the npm scripts sometimes not working in windows environments.
 
 The tricky part here is `virtualenv` from PyPi, which is the virtual python environment that incapsules a part of the scrollshot feature. `virtualenv` seems inconsistent in what paths it creates on windows on initialization. To compensate for that, there are two replacement npm scripts that might fix the python path bug:
 
 `npm run pyinstall-win` and `npm run pyfreeze-win`
 
-If they don't work, try installing and compiling the python program manually (in virtualenv). You can look at the existing scripts in `package.json` for inspiration. If you know consistent fix, please submit an issue!
+If they don't work, try installing and compiling the python program manually (in virtualenv). You can look at the existing scripts in `package.json` for inspiration. If you know of a consistent fix, please submit an issue!

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ManuScrape is a solution for managing large amounts of observations (images mapped to custom defined parameters), including tools to collect, edit, enrich and export.
 <br />
 <br />
-There are two main actors: the *project manager* and the *collaborator* (can only submit observations).
+There are two main actors: the *project manager* and the *collaborator*.
 <br />
 <br />
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ The tricky part here is `virtualenv` from PyPi, which is the virtual python envi
 `npm run pyinstall-win` and `npm run pyfreeze-win`
 
 If they don't work, try installing and compiling the python program manually (in virtualenv). You can look at the existing scripts in `package.json` for inspiration. If you know of a consistent fix, please submit an issue!
+<br />
+<br />
 
-<br />
-<br />
 ## Contributors 💥 🚀 😻
 - [@FAF2205](https://github.com/FAF2205)
 - [@Pallisgaard](https://github.com/Pallisaard)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ After the launch of v1.0.0, we intend to use GitHub Issues for all development t
 <br />
 <br />
 
-## Contribute to the code
+## Contribute to the code ☕
 You are more than welcome to contribute to the project in any way. Except donations. For now.
 
 #### TL;DR:
@@ -76,3 +76,15 @@ The tricky part here is `virtualenv` from PyPi, which is the virtual python envi
 `npm run pyinstall-win` and `npm run pyfreeze-win`
 
 If they don't work, try installing and compiling the python program manually (in virtualenv). You can look at the existing scripts in `package.json` for inspiration. If you know of a consistent fix, please submit an issue!
+
+<br />
+<br />
+## Contributors 💥 🚀 😻
+- [@FAF2205](https://github.com/FAF2205)
+- [@Pallisgaard](https://github.com/Pallisaard)
+- [@Pedrotheplant](https://github.com/Pedrotheplant)
+- [@SEilertsen](https://github.com/SEilertsen)
+- [@bjarke22](https://github.com/bjarke22)
+- [@jakobdemant](https://github.com/jakobdemant)
+- [@nabojens](https://github.com/nabojens)
+- [@nikobojs](https://github.com/nikobojs)

--- a/app/app.ts
+++ b/app/app.ts
@@ -1,5 +1,13 @@
 import { app, globalShortcut } from 'electron';
 
+// ask OS for a "single instance lock"
+// if OS supports it, app will quit if launched as second instance
+const obtainedLock = app.requestSingleInstanceLock();
+if (!obtainedLock) {
+  console.error('ManuScrape is already running. Will quit :/')
+  app.quit();
+}
+
 // https://github.com/electron/windows-installer
 const squirrelEvent = process.argv[1];
 const isSquirrel = squirrelEvent && squirrelEvent.indexOf('--squirrel') != -1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manuscrape_electron",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manuscrape_electron",
-      "version": "0.9.0",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "manuscrape_electron",
   "productName": "ManuScrape",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "description": "A system tray app foor capturing scrolling screenshotscd",
   "main": "dist/app.js",
   "scripts": {

--- a/renderers/markAreaP5Sketch.js
+++ b/renderers/markAreaP5Sketch.js
@@ -87,7 +87,7 @@ const sketch = (p) => {
     } else if(resultRect && statusText && typeof statusDescription === 'string') {
       hideArea || drawArea(p, area);
       drawProcessing(p);
-    } else {
+    } else if (!resultRect) {
       p.background(fillColor);
     }
   }


### PR DESCRIPTION
**manuscrape_electron**
- Improved documentation (@bjarke22)
- Added contributor list to main readme
- Attempt to fix overlay getting caught in screenshots ( #52 )
- Attempt to enforce max 1 instance/process of manuscrape at a time ( #43 )

**manuscrape_nuxt**
- Support deletion of collaborators (#10 )
- Support deletion of file uploads (#31)
- (Image editor) Fix textarea focus logic (#42 )
- (Image editor) Create minimum font-size (enables clicking instead of dragging a textbox) (#42 )
- Add projectname and date to export filenames (#37 )
- Add export function for observation file uploads (#17)
- Remove opacity from image thumbnail in observation dialog view
- A few small UI improvement (@nabojens)
- Error reporting configuration fixes
- Stability and usability improvements in image editor