### PR TITLE
make  pyfreeze* scripts and pythonBridge compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,29 +24,32 @@ This is the main ManuScrape repo which holds the native client side windows app 
 
 ## Basic feature overview:
 
-There are two main actors: the *project manager* and the *collaborator*.
+There are two main actors: the _project manager_ and the _collaborator_.
 <br />
 <br />
 
-*Project managers* can setup projects using the web app:
-  1. Enter project name
-  2. Define observation parameters
-  3. Invite collaborators by email
+_Project managers_ can setup projects using the web app:
 
-*Collaborators* can submit observations using the native app:
-  1. Capture image (using smart tools or file upload)
-  2. Edit image
-  3. Enter observation parameter values
-  4. Attach extra files if any
-  5. Submit observation
+1. Enter project name
+2. Define observation parameters
+3. Invite collaborators by email
+
+_Collaborators_ can submit observations using the native app:
+
+1. Capture image (using smart tools or file upload)
+2. Edit image
+3. Enter observation parameter values
+4. Attach extra files if any
+5. Submit observation
 
 Whether you're a collaborator or project owner isn't bound to your ManuScrape user, but to your permission role in the specific project.
 
-The *project manager* can export the entire project into to different formats, including spreadsheets and zip files. Right now the export features are optimized to deliver formats, that are easy to import into [NVivo 14](https://lumivero.com/products/nvivo/).
+The _project manager_ can export the entire project into to different formats, including spreadsheets and zip files. Right now the export features are optimized to deliver formats, that are easy to import into [NVivo 14](https://lumivero.com/products/nvivo/).
 <br />
 <br />
 
 ## Installation on Windows
+
 Before you start installing, you need to decide where you want to put your data. As of now, you can temporarily use [manuscrape.org](https://manuscrape.org) for free, which is also the default option in the signup flow.
 
 You can download a compiled windows installer, that will either install or update ManuScrape to the desired version. The latest .exe installer can be found [here](https://github.com/nikobojs/manuscrape_electron/releases).
@@ -54,37 +57,44 @@ You can download a compiled windows installer, that will either install or updat
 <br />
 
 ## Bug reports / Feature requests
+
 After the launch of v1.0.0, we intend to use GitHub Issues for all development tasks. If you experience bugs, or need features added or refactored, please [submit an issue](https://github.com/nikobojs/manuscrape_electron/issues), preferably in english.
 <br />
 <br />
 
 ## Contribute to the code ☕
+
 You are more than welcome to contribute to the project in any way. Except donations. For now.
 
 #### TL;DR:
+
 Clone repositories, look for TODO-comments, make improvement, create feature branch (naming doesn't matter), commit, create PR, and done! The PR will be reviewed by the project maintainers.
 <br />
 
 #### Repository overview:
+
 This repo is an Electron app tested on Windows 11 and a couple Linux distributions. The app provides some client-side native tools, that talks with the api of the online backend app. [Here is the backend repo](https://github.com/nikobojs/manuscrape_nuxt). These two repositories follows compatability with git tags (eg. `v0.9.2` client works with `v0.9.2` api).
 <br />
 
 #### Git conventions:
+
 Not strict in any way. Make your contributions the way you think works best. Pull requests (into "unstable" branch) on feature branches will be reviewed and merged by the current admins of the project.
 <br />
 
 #### Setup on Linux or Mac:
+
 1. Install Electron repository:
-	1. `git clone https://github.com/nikobojs/manuscrape_electron`
-	2. `cd manuscrape_electron`
-	3. `npm install`
-	4. `npm pyinstall`
-	5. `npm pyfreeze`
+   1. `git clone https://github.com/nikobojs/manuscrape_electron`
+   2. `cd manuscrape_electron`
+   3. `npm install`
+   4. `npm run pyinstall`
+   5. `npm run pyfreeze`
 2. [Install ManuScrape Nuxt repository](https://github.com/nikobojs/manuscrape_nuxt)
-5. Start Nuxt app: `cd manuscrape_nuxt && yarn dev`
-6. Start Electron app: `cd manuscrape_electron && npm start`
+3. Start Nuxt app: `cd manuscrape_nuxt && yarn dev`
+4. Start Electron app: `cd manuscrape_electron && npm start`
 
 #### Setup on Windows:
+
 _NOTE: Development ennvironment for windows is not actively maintained or tested_
 <br />
 <br />
@@ -99,6 +109,7 @@ If they don't work, try installing and compiling the python program manually (in
 <br />
 
 ## Contributors 💥 🚀 😻
+
 - [@FAF2205](https://github.com/FAF2205)
 - [@Mod-lab-stoff](https://github.com/Mod-lab-stoff)
 - [@Pallisgaard](https://github.com/Pallisaard)

--- a/app/helpers/pythonBridge.ts
+++ b/app/helpers/pythonBridge.ts
@@ -1,84 +1,88 @@
-import path from 'path';
-import { app } from 'electron';
-import fs from 'node:fs';
-import { spawn } from 'node:child_process'
+import path from "path";
+import { app } from "electron";
+import fs from "node:fs";
+import { spawn } from "node:child_process";
 
 function getChatJoinerPath(): string {
-    const isWindows = process.platform === 'win32'
-    const filename = isWindows ? 'chatjoiner.exe' : 'chatjoiner';
-    const isPackaged = app.isPackaged;
-  
-    if (isPackaged) {
-        return path.join(process.resourcesPath, filename);
-    } else {
-        return path.join(__dirname, '..', '..', 'python', 'dist', filename);
-    }
+  const isPackaged = app.isPackaged;
+  const isWindows = process.platform === "win32";
+  const filename = isWindows ? "chatjoiner.exe" : "chatjoiner";
+
+  if (isPackaged) {
+    return path.join(process.resourcesPath, filename);
+  }
+
+  return path.join(__dirname, "..", "..", "python", "dist", filename);
 }
 
 export function ensurePythonAvail(): void {
-    const p = getChatJoinerPath();
-    const exists = fs.existsSync(p);
-    if (!exists) {
-        console.error('Invalid chatjoiner.exe path:', p);
-        throw new Error('ManuScrape Electron app could not find the internal python utilities');
-    }
+  const p = getChatJoinerPath();
+  const exists = fs.existsSync(p);
+  if (!exists) {
+    console.error("Invalid path to chatjoiner executable:", p);
+    throw new Error(
+      "ManuScrape Electron app could not find the internal python utilities"
+    );
+  }
 }
 
-
 export function joinImagesVertically(
-    imagesDir: string,
-    outputPath: string,
-    settings: ScrollshotSettings,
+  imagesDir: string,
+  outputPath: string,
+  settings: ScrollshotSettings
 ): Promise<void> {
-    console.log('starting to join images...');
-    return new Promise((resolve, reject) => {
-        const chatjoinerPath = getChatJoinerPath();
+  console.log("starting to join images...");
+  return new Promise((resolve, reject) => {
+    const chatjoinerPath = getChatJoinerPath();
 
-        const beginTime = new Date().getTime();
-        const args = [
-            imagesDir,
-            '--n_rows_in_crop',
-            '' + settings.rowsPrCrop,
-            '--n_cols_in_crop',
-            '' + settings.colsPrCrop,
-            '--denoising_factor',
-            '' + settings.denoisingFactor,
-            '--match_score_threshold',
-            '' + settings.matchScoreThreshold,
-            '--left_crop_from',
-            '' + settings.leftCropFrom,
-            '--right_crop_from',
-            '' + settings.rightCropFrom,
-            '--left_crop_to',
-            '' + settings.leftCropTo,
-            '--right_crop_to',
-            '' + settings.rightCropTo,
-            '-o',
-            outputPath,
-        ];
-        const python = spawn(chatjoinerPath, args);
+    const beginTime = new Date().getTime();
+    const args = [
+      imagesDir,
+      "--n_rows_in_crop",
+      "" + settings.rowsPrCrop,
+      "--n_cols_in_crop",
+      "" + settings.colsPrCrop,
+      "--denoising_factor",
+      "" + settings.denoisingFactor,
+      "--match_score_threshold",
+      "" + settings.matchScoreThreshold,
+      "--left_crop_from",
+      "" + settings.leftCropFrom,
+      "--right_crop_from",
+      "" + settings.rightCropFrom,
+      "--left_crop_to",
+      "" + settings.leftCropTo,
+      "--right_crop_to",
+      "" + settings.rightCropTo,
+      "-o",
+      outputPath,
+    ];
+    const python = spawn(chatjoinerPath, args);
 
-        const debugCmd = chatjoinerPath + args.join(' ');
-        console.info('> ' + debugCmd)
-    
-        python.stdout.on("data", function (data: string) {
-            console.info(data)
-        });
-    
-        python.stderr.on("data", (data: string) => {
-            console.error(`stderr: ${data}`);
-            console.log(`stderr: ${data}`);
-        }); 
-    
-        python.on("close", (code: number) => {
-            console.info('python program exited with code', code);
-            if (code === 0) {
-                console.log('saved result image:', outputPath);
-                console.log('python program took', ((new Date().getTime() - beginTime) / 1000).toFixed(2) + 's')
-                resolve();
-            } else {
-                reject();
-            }
-        });
-    })
+    const debugCmd = chatjoinerPath + args.join(" ");
+    console.info("> " + debugCmd);
+
+    python.stdout.on("data", function (data: string) {
+      console.info(data);
+    });
+
+    python.stderr.on("data", (data: string) => {
+      console.error(`stderr: ${data}`);
+      console.log(`stderr: ${data}`);
+    });
+
+    python.on("close", (code: number) => {
+      console.info("python program exited with code", code);
+      if (code === 0) {
+        console.log("saved result image:", outputPath);
+        console.log(
+          "python program took",
+          ((new Date().getTime() - beginTime) / 1000).toFixed(2) + "s"
+        );
+        resolve();
+      } else {
+        reject();
+      }
+    });
+  });
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "manuscrape_electron",
   "productName": "ManuScrape",
   "version": "1.0.6",
-  "description": "A system tray app foor capturing scrolling screenshotscd",
+  "description": "A system tray app foor capturing scrolling screenshots",
   "main": "dist/app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -13,8 +13,8 @@
     "pyinstall": "npm run delete-venv && cd python && . env/bin/activate && pip3 install -r requirements.txt && deactivate",
     "pyinstall-win": "cd python && env\\Scripts\\activate && pip install -r requirements.txt && deactivate",
     "delete-venv": "rm -rf python/env && (cd python && python3 -m venv env)",
-    "pyfreeze": "cd python && . env/bin/activate && pyinstaller -F --distpath ./python/dist -n chatjoiner src/main.py && deactivate",
-    "pyfreeze-win": "python\\env\\Scripts\\activate && pyinstaller -F --distpath ./python/dist -n chatjoiner python\\src\\main.py && deactivate",
+    "pyfreeze": "cd python && . env/bin/activate && pyinstaller -F --distpath ./dist -n chatjoiner src/main.py && deactivate",
+    "pyfreeze-win": "python\\env\\Scripts\\activate && pyinstaller -F --distpath ./dist -n chatjoiner python\\src\\main.py && deactivate",
     "build-tailwindcss": "npx tailwindcss -i tailwind.config.css -o assets/tailwind.min.css --minify"
   },
   "author": "Københavns Universitet",


### PR DESCRIPTION
It used to put "chatjoiner(.exe)" in python/python/dist, but it was looking for it in python/dist in getChatjoinerPath() (in local development at least, when the app is packaged it is different). 

Also updated README to make commands work (added "run" to 2 nom commands). Im not sure if this is universal or just a mac thing.